### PR TITLE
Update Windows and Linux's NodeBB installation instructions

### DIFF
--- a/docs/projects/P1/installation/mac.md
+++ b/docs/projects/P1/installation/mac.md
@@ -7,29 +7,31 @@ First, install the following programs:
 -   <http://nodejs.org/>
 -   <http://brew.sh/>
 
-## Installing NodeBB
+### Installing Redis
 
 Install redis with homebrew:
 
-```sh
+```console
 % brew install redis
 ```
 
 Start the redis server:
 
-```sh
+```console
 % redis-server
 ```
 
-You should have already cloned your NodeBB repository onto your local machine. Enter the directory where you've cloned the repository:
+## Installing NodeBB
 
-```sh
+You should have already cloned your NodeBB repository onto your local machine. Enter the directory where you have cloned the repository:
+
+```console
 % cd NodeBB
 ```
 
 Run the interactive installation command:
 
-```sh
+```console
 % ./nodebb setup
 ```
 
@@ -37,7 +39,7 @@ You will then be presented with a series of setup questions.
 
 For each of the questions — **except for "Which database to use (mongo)"**, which you should answer with "redis" — you may accept the default answer by pressing ++enter++
 
-```
+```console
 URL used to access this NodeBB (http://127.0.0.1:4567) 
 Please enter a NodeBB secret (ee18b7c3-1d23-41c9-800f-78d74acc0861) 
 Would you like to submit anonymous plugin usage to nbbpm? (yes) 
@@ -50,14 +52,19 @@ Password of your Redis database
 Which database to use (0..n) (0) 
 ```
 
-The first time you run the `setup` command, you will be asked to configure a forum administrator. When prompted, enter the desired information for the admin account.
+The first time you run the `setup` command, you will also be asked to configure a forum administrator. When prompted, enter the desired information for the admin account.
 
 Once everything has finished installing, a configuration file `config.json` will be created. This file can be modified if you need to make changes to the above settings, such as the database location or credentials used to access the database.
 
-After the installation, run:
+After the installation, build the files:
 
-```sh
+```console
 % ./nodebb build
+```
+
+And start the NodeBB server:
+
+```console
 % ./nodebb start
 ```
 

--- a/docs/projects/P1/installation/ubuntu.md
+++ b/docs/projects/P1/installation/ubuntu.md
@@ -7,120 +7,90 @@
 Node.js is available from the NodeSource Ubuntu binary distributions repository.
 
 ```sh
-% curl -sL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
-% sudo apt-get install -y nodejs
+curl -sL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+```
+```sh
+sudo apt-get install -y nodejs
 ```
 
-Verify installation of Node.js and npm. You should have version lts of Node.js installed, and version 8 of npm installed:
+Verify installation of Node.js and npm. You should have version LTS of Node.js installed, and version 8 of npm installed:
 
 ```sh
 node -v
 npm -v // should output "8.11.0" or similar
 ```
 
-### Installing MongoDB
+### Installing Redis
+The original NodeBB installation guide suggests the use of MongoDB database, but we have found more success with using Redis as the database.
 
-The following is an abbreviation of the official [MongoDB installation guide for Ubuntu](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/).
+Here's an abbreviated version of the instructions provided by [Redis](https://redis.io/docs/getting-started/installation/install-redis-on-linux/):
 
-```sh
-% wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | sudo apt-key add -
-% echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-5.0.list
-% sudo apt-get update
-% sudo apt-get install -y mongodb-org
-```
-
-**Verify installation of MongoDB.** You should have version 5.0:
+Add Redis repository to the apt index:
 
 ```sh
-mongod --version
-db version v5.0
+curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
 ```
-
-**Start the mongod service and verify service status:**
 
 ```sh
-sudo systemctl start mongod
-sudo systemctl status mongod
+echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
 ```
 
-
-## Configure MongoDB
-General MongoDB administration is done through the MongoDB Shell `mongo`. A default installation of MongoDB listens on port `27017` and is accessible locally. Access the shell:
+Update and install:
 
 ```sh
-% mongo
+sudo apt-get update
+sudo apt-get install redis
 ```
 
-Switch to the built-in admin database:
-
-```mongodb
-> use admin
-```
-
-Create an administrative user (the is different from the `nodebb` user we'll create later). Replace the placeholder `<Enter a secure password>` with your own selected password. Be sure that the `<` and `>` are also not left behind.
-
-```mongodb
-> db.createUser( { user: "admin", pwd: "<Enter a secure password>", roles: [ { role: "root", db: "admin" } ] } )
-```
-
-This user is scoped to the admin database to manage MongoDB once authorization has been enabled.
-
-To initially create a database that doesn't exist simply `use` it. Add a new database called `nodebb`:
-
-```mongodb
-> use nodebb
-```
-
-The database will be created and context switched to `nodebb`. Next create the `nodebb` user with the appropriate privileges:
-
-```mongodb
-> db.createUser( { user: "nodebb", pwd: "<Enter a secure password>", roles: [ { role: "readWrite", db: "nodebb" }, { role: "clusterMonitor", db: "admin" } ] } )
-```
-
-The `readWrite` permission allows NodeBB to store and retrieve data from the `nodebb` database. The `clusterMonitor` permission provides NodeBB read-only access to query database server statistics which are then exposed in the NodeBB Administrative Control Panel (ACP).
-
-Exit the Mongo Shell:
-
-```mongodb
-> quit()
-```
-
-Restart MongoDB and verify the administrative user created earlier can connect:
+Start the redis server:
 
 ```sh
-% sudo systemctl restart mongod
-% mongo -u admin -p your_password --authenticationDatabase=admin
+redis-server
 ```
-If everything is configured correctly the Mongo Shell will connect. Exit the shell.
-
 
 ## Installing NodeBB
 
 You should have already cloned your NodeBB repository onto your local machine. Enter the directory where you've cloned the repository:
 
 ```sh
-% cd NodeBB
+cd NodeBB
 ```
 
 Run the interactive installation command:
 
 ```sh
-% ./nodebb setup
+./nodebb setup
 ```
 
-You will then be presented with a series of setup questions. For each of the questions, you may accept the default answer by pressing ++enter++
+For each of the questions — **except for "Which database to use (mongo)"**, which you should answer with "redis" — you may accept the default answer by pressing ++enter++
 
-When prompted for the `mongodb` username and password, enter `nodebb`, and the password that you configured earlier. Once connectivity to the database is confirmed, the setup will prompt that initial user setup is running. 
+```
+URL used to access this NodeBB (http://127.0.0.1:4567) 
+Please enter a NodeBB secret (ee18b7c3-1d23-41c9-800f-78d74acc0861) 
+Would you like to submit anonymous plugin usage to nbbpm? (yes) 
+Which database to use (mongo) redis
+
+Now configuring redis database:
+Host IP or address of your Redis instance (127.0.0.1) 
+Host port of your Redis instance (6379) 
+Password of your Redis database 
+Which database to use (0..n) (0) 
+```
 
 The first time you run the `setup` command, you will be asked to configure a forum administrator. When prompted, enter the desired information for the admin account.
 
 Once everything has finished installing, a configuration file `config.json` will be created. This file can be modified if you need to make changes to the above settings, such as the database location or credentials used to access the database.
 
-After the installation, run:
+After the installation, build the executable:
 
 ```sh
-% ./nodebb build
-% ./nodebb start
+./nodebb build
+```
+
+Then start the nodebb server:
+
+```sh
+./nodebb start
 ```
 
 You can now visit your forum at [`http://localhost:4567/`](http://localhost:4567/).

--- a/docs/projects/P1/installation/ubuntu.md
+++ b/docs/projects/P1/installation/ubuntu.md
@@ -4,67 +4,70 @@
 
 ### Installing Node.js
 
-Node.js is available from the NodeSource Ubuntu binary distributions repository.
+Node.js is available from the NodeSource Ubuntu binary distributions repository. Start by adding this repository to the apt index:
 
-```sh
-curl -sL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+```console
+% curl -sL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
 ```
-```sh
-sudo apt-get install -y nodejs
+
+Then, update the apt packages and install nodejs:
+```console
+% sudo apt-get update
+% sudo apt-get install -y nodejs
 ```
 
 Verify installation of Node.js and npm. You should have version LTS of Node.js installed, and version 8 of npm installed:
 
-```sh
-node -v
-npm -v // should output "8.11.0" or similar
+```console
+% node -v
+% npm -v      # this should output "8.11.0" or similar
 ```
 
 ### Installing Redis
-The original NodeBB installation guide suggests the use of MongoDB database, but we have found more success with using Redis as the database.
 
-Here's an abbreviated version of the instructions provided by [Redis](https://redis.io/docs/getting-started/installation/install-redis-on-linux/):
+The original NodeBB installation guide suggests the use of MongoDB database, but for simplicity and consistency across the installation guides, we will be using Redis as our database.
+
+Here is an abbreviated version of the installation instructions provided by [Redis](https://redis.io/docs/getting-started/installation/install-redis-on-linux/):
 
 Add Redis repository to the apt index:
 
-```sh
-curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+```console
+% curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+% echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
 ```
 
-```sh
-echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
-```
+Update the apt packages and install redis:
 
-Update and install:
-
-```sh
-sudo apt-get update
-sudo apt-get install redis
+```console
+% sudo apt-get update
+% sudo apt-get install redis
 ```
 
 Start the redis server:
 
-```sh
-redis-server
+```console
+% redis-server
 ```
 
 ## Installing NodeBB
 
-You should have already cloned your NodeBB repository onto your local machine. Enter the directory where you've cloned the repository:
+You should have already cloned your NodeBB repository onto your local machine. Enter the directory where you have cloned the repository:
 
-```sh
-cd NodeBB
+```console
+% cd NodeBB
 ```
 
 Run the interactive installation command:
 
-```sh
-./nodebb setup
+```console
+% ./nodebb setup
 ```
+
+You will then be presented with a series of setup questions. 
 
 For each of the questions — **except for "Which database to use (mongo)"**, which you should answer with "redis" — you may accept the default answer by pressing ++enter++
 
-```
+```console
 URL used to access this NodeBB (http://127.0.0.1:4567) 
 Please enter a NodeBB secret (ee18b7c3-1d23-41c9-800f-78d74acc0861) 
 Would you like to submit anonymous plugin usage to nbbpm? (yes) 
@@ -77,20 +80,20 @@ Password of your Redis database
 Which database to use (0..n) (0) 
 ```
 
-The first time you run the `setup` command, you will be asked to configure a forum administrator. When prompted, enter the desired information for the admin account.
+The first time you run the `setup` command, you will also be asked to configure a forum administrator. When prompted, enter the desired information for the admin account.
 
 Once everything has finished installing, a configuration file `config.json` will be created. This file can be modified if you need to make changes to the above settings, such as the database location or credentials used to access the database.
 
-After the installation, build the executable:
+After the installation, build the files:
 
-```sh
-./nodebb build
+```console
+% ./nodebb build
 ```
 
-Then start the nodebb server:
+And start the NodeBB server:
 
-```sh
-./nodebb start
+```console
+% ./nodebb start
 ```
 
 You can now visit your forum at [`http://localhost:4567/`](http://localhost:4567/).

--- a/docs/projects/P1/installation/windows.md
+++ b/docs/projects/P1/installation/windows.md
@@ -1,22 +1,23 @@
 # Installing NodeBB on Windows
 
-17-313 will only be supporting Windows Subsystem Linux 2 (WSL2), Ubuntu variant, on Windows. It's highly recommended that you develop using VSCode as well. Refer to Microsoft's official documentation on what is [WSL](https://learn.microsoft.com/en-us/windows/wsl/about).
+17-313 will only be supporting development using Windows Subsystem Linux 2 (WSL2) on Windows (Ubuntu variant). To support the use of WSL2, it is **highly recommended** that you develop using [VSCode](https://code.visualstudio.com/download). To learn more, refer to Microsoft's official [WSL Documentation](https://learn.microsoft.com/en-us/windows/wsl/about).
 
 ## Installing WSL2 on Windows
 
-Follow the instructions on the official [Get Started Guide](https://learn.microsoft.com/en-us/windows/wsl/setup/environment#get-started), and ensure you complete all the steps until (and including) **Use Visual Studio Code**.
+Follow the instructions on the official Microsoft [Getting Started Guide](https://learn.microsoft.com/en-us/windows/wsl/setup/environment#get-started) and complete all the steps up to (and including) the [**Use Visual Studio Code**](https://learn.microsoft.com/en-us/windows/wsl/setup/environment#use-visual-studio-code) section.
 
-By the end of the instructions you should:
+By the end of these instructions, you should:
 
 - [ ] Have Ubuntu WSL2 installed
-- [ ] Have a root Linux username and password setup
+- [ ] Have a root Linux username and password set up
 - [ ] Have updated and upgraded your packages
 - [ ] Be able to open Ubuntu WSL2 in Windows Terminal
-- [ ] Understand that you should **store your project files on the same operating system as the tools you plan to use.** You should for example, be doing `git clone` in your Ubuntu file system, open the directory in Ubuntu, and edit the code in Ubuntu.
+- [ ] Understand that you should **store your project files on the same operating system as the tools you plan to use**. For example, in order to successfully run NodeBB in Ubuntu, you should run `git clone` in your Ubuntu file system, open the cloned directory in Ubuntu, and edit the code files in Ubuntu
 - [ ] Be able to open a directory in Ubuntu in VSCode
 
-In all future projects of this course, you should develop using WSL2. It is thus very important that you setup WSL2 correctly; come to office hours if you need any assistance with the installation.
+!!! note
+    In all future projects of this course, we will expect you to develop using WSL2. Thus, it is **very important** that you set up WSL2 correctly. Please come to office hours or ask on Slack if you need any assistance with the installation.
 
 ## Installing NodeBB
 
-Follow the [Ubuntu](ubuntu.md) instructions to install NodeBB.
+Follow the [Ubuntu](/projects/P1/installation/ubuntu) instructions to install required tools on WSL2 and NodeBB itself.

--- a/docs/projects/P1/installation/windows.md
+++ b/docs/projects/P1/installation/windows.md
@@ -1,6 +1,6 @@
 # Installing NodeBB on Windows
 
-We will only be supporting Windows Subsystem Linux 2 (WSL2), Ubuntu variant, on Windows, and it's highly recommended that you develop using VSCode. Refer to Microsoft's official documentation on what is [WSL](https://learn.microsoft.com/en-us/windows/wsl/about).
+17-313 will only be supporting Windows Subsystem Linux 2 (WSL2), Ubuntu variant, on Windows. It's highly recommended that you develop using VSCode as well. Refer to Microsoft's official documentation on what is [WSL](https://learn.microsoft.com/en-us/windows/wsl/about).
 
 ## Installing WSL2 on Windows
 
@@ -19,4 +19,4 @@ In all future projects of this course, you should develop using WSL2. It is thus
 
 ## Installing NodeBB
 
-You will now be able to follow the [Ubuntu](ubuntu.md) instructions to install NodeBB.
+Follow the [Ubuntu](ubuntu.md) instructions to install NodeBB.

--- a/docs/projects/P1/installation/windows.md
+++ b/docs/projects/P1/installation/windows.md
@@ -1,153 +1,22 @@
 # Installing NodeBB on Windows
 
-## Required Software
+We will only be supporting Windows Subsystem Linux 2 (WSL2), Ubuntu variant, on Windows, and it's highly recommended that you develop using VSCode. Refer to Microsoft's official documentation on what is [WSL](https://learn.microsoft.com/en-us/windows/wsl/about).
 
-### Installing Node.js
+## Installing WSL2 on Windows
 
-- [Download Node.js lts](https://nodejs.org/)
-- Execute the installer
+Follow the instructions on the official [Get Started Guide](https://learn.microsoft.com/en-us/windows/wsl/setup/environment#get-started), and ensure you complete all the steps until (and including) **Use Visual Studio Code**.
 
-Verify installation of Node.js and npm. You should have version lts of Node.js installed, and version 8 of npm installed:
+By the end of the instructions you should:
 
-```sh
-% node -v
-% npm -v // should output "8.11.0" or similar
-```
+- [ ] Have Ubuntu WSL2 installed
+- [ ] Have a root Linux username and password setup
+- [ ] Have updated and upgraded your packages
+- [ ] Be able to open Ubuntu WSL2 in Windows Terminal
+- [ ] Understand that you should **store your project files on the same operating system as the tools you plan to use.** You should for example, be doing `git clone` in your Ubuntu file system, open the directory in Ubuntu, and edit the code in Ubuntu.
+- [ ] Be able to open a directory in Ubuntu in VSCode
 
-### Installing MongoDB
-The following is an abbreviation of the official [MongoDB installation guide for Windows](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows/).
-
-Go to the [MongoDB Download Center](https://www.mongodb.com/download-center#production) and download the appropriate setup file for your computer. Then, locate the downloaded `.msi` file and execute it to start the installer. The default installation location is `C:\Program Files\MongoDB\Server\5.0`.
-
-**Add the MongoDB binaries to your PATH:**
-
-- Find the bin directory under your MongoDB installation The default path is `C:\Program Files\MongoDB\Server\5.0\bin`
-- Type PATH into the Start Menu search bar
-- Open **Edit environment variables for your account**
-- Under **User variable for [your username]**, click on `Path`
-- Click the **Edit...** button
-- Click the **New button** on the right
-- Type or paste in the full path to the `bin` directory
-
-**Configure a service for the `mongod` server:**
-
-- Type "cmd" or "Command Prompt" into the Start Menu search bar
-- Right-click "Command Prompt" and select "Run as Administrator".
-- Create two directories for your database and log files using the `mkdir` command:
-    - `% mkdir C:\MongoDB\data\db`
-    - `% mkdir C:\MongoDB\logs`
-- Create a config file (`C:\MongoDB\mongod.cfg`) with the following contents:
-
-```
-systemLog:
-    destination: file
-    path: C:\MongoDB\logs\mongod.log
-storage:
-    dbPath: C:\MongoDB\data\db
-security:
-    authorization: enabled
-```
-
-**Install the MongoDB service:**
-
-```sh
-mongod.exe --config "C:\MongoDB\mongod.cfg" --install
-```
-
-**Verify installation of MongoDB.** You should have version 5.0:
-
-```sh
-% mongod --version
-db version v5.0
-```
-
-**Start the mongod service and verify service status:**
-
-```sh
-% net start MongoDB
-% sc query "MongoDB" | findstr STATE
-```
-
-
-## Configure MongoDB
-General MongoDB administration is done through the MongoDB Shell `mongo`. A default installation of MongoDB listens on port `27017` and is accessible locally. Access the shell:
-
-```sh
-% mongo
-```
-
-Switch to the built-in admin database:
-
-```mongodb
-> use admin
-```
-
-Create an administrative user (the is different from the `nodebb` user we'll create later). Replace the placeholder `<Enter a secure password>` with your own selected password. Be sure that the `<` and `>` are also not left behind.
-
-```mongodb
-> db.createUser( { user: "admin", pwd: "<Enter a secure password>", roles: [ { role: "root", db: "admin" } ] } )
-```
-
-This user is scoped to the admin database to manage MongoDB once authorization has been enabled.
-
-To initially create a database that doesn't exist simply `use` it. Add a new database called `nodebb`:
-
-```mongodb
-> use nodebb
-```
-
-The database will be created and context switched to `nodebb`. Next create the `nodebb` user with the appropriate privileges:
-
-```mongodb
-> db.createUser( { user: "nodebb", pwd: "<Enter a secure password>", roles: [ { role: "readWrite", db: "nodebb" }, { role: "clusterMonitor", db: "admin" } ] } )
-```
-
-The `readWrite` permission allows NodeBB to store and retrieve data from the `nodebb` database. The `clusterMonitor` permission provides NodeBB read-only access to query database server statistics which are then exposed in the NodeBB Administrative Control Panel (ACP).
-
-Exit the Mongo Shell:
-
-```mongodb
-> quit()
-```
-
-Restart MongoDB and verify the administrative user created earlier can connect:
-
-```sh
-% net stop MongoDB
-% net start MongoDB
-% mongo -u admin -p your_password --authenticationDatabase=admin
-```
-
-If everything is configured correctly the Mongo Shell will connect. Exit the shell.
-
+In all future projects of this course, you should develop using WSL2. It is thus very important that you setup WSL2 correctly; come to office hours if you need any assistance with the installation.
 
 ## Installing NodeBB
 
-You should have already cloned your NodeBB repository onto your local machine. Enter the directory where you've cloned the repository:
-
-```sh
-% cd NodeBB
-```
-
-Run the interactive installation command:
-
-```sh
-% nodebb setup
-```
-
-You will then be presented with a series of setup questions. For each of the questions, you may accept the default answer by pressing ++enter++
-
-When prompted for the `mongodb` username and password, enter `nodebb`, and the password that you configured earlier. Once connectivity to the database is confirmed, the setup will prompt that initial user setup is running. 
-
-The first time you run the `setup` command, you will be asked to configure a forum administrator. When prompted, enter the desired information for the admin account.
-
-Once everything has finished installing, a configuration file `config.json` will be created. This file can be modified if you need to make changes to the above settings, such as the database location or credentials used to access the database.
-
-After the installation, run:
-
-```sh
-% nodebb build
-% nodebb start
-```
-
-You can now visit your forum at [`http://localhost:4567/`](http://localhost:4567/).
+You will now be able to follow the [Ubuntu](ubuntu.md) instructions to install NodeBB.


### PR DESCRIPTION
- Recommends using Redis for Ubuntu
- Changes Windows instructions to direct them to use WSL2