### PR TITLE
Adds WSL2 git clone directory disclaimer

### DIFF
--- a/docs/projects/P1/index.md
+++ b/docs/projects/P1/index.md
@@ -52,7 +52,7 @@ If you are not familiar with any of these steps, you are **highly recommended** 
 ## Getting Started
 
 ### Repository Setup
-Fork the [class-specific repository](https://github.com/CMU-313/NodeBB) into your personal GitHub account and clone the repository onto your local machine.
+Fork the [class-specific repository](https://github.com/CMU-313/NodeBB) into your personal GitHub account
 
 !!! warning
 	Even though this project is based off of an active open source project, we have made significant changes to ensure its suitability for our class. As such, be sure you are forking off of **CMU-313/NodeBB** and direct any questions to course staff. Do **not** contact the maintainers of NodeBB for assistance with your homework questions.

--- a/docs/projects/P1/installation/mac.md
+++ b/docs/projects/P1/installation/mac.md
@@ -23,7 +23,9 @@ Start the redis server:
 
 ## Installing NodeBB
 
-You should have already cloned your NodeBB repository onto your local machine. Enter the directory where you have cloned the repository:
+You should have already forked the [class-specific repository](https://github.com/CMU-313/NodeBB). Clone your forked repository into your local machine.
+
+Enter the directory where you have cloned the repository:
 
 ```console
 % cd NodeBB

--- a/docs/projects/P1/installation/ubuntu.md
+++ b/docs/projects/P1/installation/ubuntu.md
@@ -51,7 +51,15 @@ Start the redis server:
 
 ## Installing NodeBB
 
-You should have already cloned your NodeBB repository onto your local machine. Enter the directory where you have cloned the repository:
+You should have already forked the [class-specific repository](https://github.com/CMU-313/NodeBB). Clone your forked repository into your local machine.
+
+!!! warning
+    Last warning for Windows WSL2 users, you should [**store your project files on the same operating system as the tools you plan to use**](https://learn.microsoft.com/en-us/windows/wsl/filesystems#file-storage-and-performance-across-file-systems). When it comes to cloning the NodeBB repository specifically, it means that you should clone it in:
+
+    - the Linux file system root directory: `\\wsl$\Ubuntu\home\<user name>\`
+    - **not** the Windows file system root directory: `/mnt/c/Users/<user name>/$` or `C:\Users\<user name>\`
+
+    You can do `cd ~` to access the linux home
 
 ```console
 % cd NodeBB

--- a/docs/projects/P1/installation/windows.md
+++ b/docs/projects/P1/installation/windows.md
@@ -1,6 +1,8 @@
 # Installing NodeBB on Windows
 
-17-313 will only be supporting development using Windows Subsystem Linux 2 (WSL2) on Windows (Ubuntu variant). To support the use of WSL2, it is **highly recommended** that you develop using [VSCode](https://code.visualstudio.com/download). To learn more, refer to Microsoft's official [WSL Documentation](https://learn.microsoft.com/en-us/windows/wsl/about).
+17-313 will only be supporting development using Windows Subsystem Linux 2 (WSL2) on Windows (Ubuntu variant). To support the use of WSL2, it is **highly recommended** that you develop using [VSCode](https://code.visualstudio.com/download). 
+
+To learn more, refer to Microsoft's official [WSL Documentation](https://learn.microsoft.com/en-us/windows/wsl/about).
 
 ## Installing WSL2 on Windows
 
@@ -12,7 +14,7 @@ By the end of these instructions, you should:
 - [ ] Have a root Linux username and password set up
 - [ ] Have updated and upgraded your packages
 - [ ] Be able to open Ubuntu WSL2 in Windows Terminal
-- [ ] Understand that you should **store your project files on the same operating system as the tools you plan to use**. For example, in order to successfully run NodeBB in Ubuntu, you should run `git clone` in your Ubuntu file system, open the cloned directory in Ubuntu, and edit the code files in Ubuntu
+- [ ] Understand that you should [**store your project files on the same operating system as the tools you plan to use**](https://learn.microsoft.com/en-us/windows/wsl/filesystems#file-storage-and-performance-across-file-systems). For example, in order to successfully run NodeBB in Ubuntu, you should run `git clone` in your Ubuntu file system, open the cloned directory in Ubuntu, and edit the code files in Ubuntu
 - [ ] Be able to open a directory in Ubuntu in VSCode
 
 !!! note


### PR DESCRIPTION
**Description**
- Moves git clone step into device specific instructions (this is to prevent Windows users from doing a `git clone` before they have WSL2 set up)
- Adds warning for WSL2 users in Ubuntu instructions

**Rationale**
From testing installation on a WSL2 linux, we realize if you install NodeBB on the Windows filesystem, it will slow to a crawl. So much so that all the performance based test cases will fail. 

Currently, because git clone step is before the device specific instructions, students would likely not do another git clone after following the WSL2 steps, and reused the one that they have cloned into the windows filesystem. Moving it after they have installed WSL2 would address the issue. 