### PR TITLE
Auto-deploy website with weekly script udpate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: # Can be invoked manually from the UI
+  workflow_call:     # Can be invoked from other workflows
 permissions:
   contents: write
 jobs:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -38,3 +38,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: main
+
+      - name: Deploy website
+        uses: ./.github/workflows/deploy.yml


### PR DESCRIPTION
It seems that when the weekly cron job runs the script to update what's next in this week, the push to `main` branch does not trigger an auto-deploy of the GitHub pages because of some restriction on workflows triggering other workflows.

This PR is intended to fix it by using [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows). It has not been tested because it needs to be on main to run.