### PR TITLE
Add recitation 2 to site

### DIFF
--- a/docs/_data/schedule.yaml
+++ b/docs/_data/schedule.yaml
@@ -192,10 +192,10 @@
     link: ''
     name: ''
   recitation:
-    handout: ''
-    name: ''
-    quiz: ''
-    slides: ''
+    handout: '/recitations/reci2-teamcontract/'
+    name: 'Recitation 2 - Team Contract Workshop'
+    quiz: 'https://www.gradescope.com/courses/703665/assignments/4006103'
+    slides: 'https://docs.google.com/presentation/d/1QuX5Ylp3ColNwc-YUpkHO0_HzCRtL8PUAJT2qX5mSUE/edit?usp=sharing'
 
 - date: Tue Jan 30
   homework:
@@ -1476,16 +1476,3 @@
     slides: ''
     deadline: ""
     link: ""
-    name: ""
-    numDays: 0
-  lecture:
-    link: ""
-    name: ""
-  reading:
-    link: ""
-    name: ""
-  recitation:
-    handout: ""
-    name: ""
-    quiz: ""
-    slides: ""

--- a/docs/_data/this_week.yaml
+++ b/docs/_data/this_week.yaml
@@ -12,8 +12,8 @@ lectures:
 projects: []
 
 recitation:
-  date: Mon Jan 22
-  handout: /recitations/reci1-github/
-  name: Recitation 1 - Git, GitHub and TypeScript
-  quiz: https://www.gradescope.com/courses/703665/assignments/3967904
-  slides: https://docs.google.com/presentation/d/1js-OQoNlUZ32OO8U3-Tz4IpCwTeKl7j7/edit?usp=sharing&ouid=116435991719159948286&rtpof=true&sd=true
+  date: Mon Jan 29
+  handout: /recitations/reci2-teamcontract/
+  name: Recitation 2 - Team Contract Workshop
+  quiz: https://www.gradescope.com/courses/703665/assignments/4006103
+  slides: https://docs.google.com/presentation/d/1QuX5Ylp3ColNwc-YUpkHO0_HzCRtL8PUAJT2qX5mSUE/edit?usp=sharing

--- a/docs/recitations/reci2-teamcontract.md
+++ b/docs/recitations/reci2-teamcontract.md
@@ -15,7 +15,7 @@ After this recitation, students will have met their teams and completed a rough 
 
 ## Activity 1: Get to know your team! 
 
-See team assignments [here](https://docs.google.com/spreadsheets/d/1rIUXlOwlWRKUeLeUPmlqsJYNT9LCDucV5FTepZm4XDs/edit?usp=sharing). Do some quick intros, then get ready for.. 
+See team assignments [here](https://docs.google.com/spreadsheets/d/1Y8kAzHbkgem53f8KZP7hM99c742iYWvowaOcVx_YFuI/edit?usp=sharing). Do some quick intros, then get ready for.. 
   
 ### **Activity 1a: Similarities!**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,7 +90,7 @@ nav:
   - Recitations:
       # - recitations/index.md # Dummy home page; remove once we start adding recitations below
       - Recitation 1 - Git, GitHub and TypeScript: recitations/reci1-github.md
-      # - Recitation 2 - Team Contract Workshop: recitations/reci2-teamcontract.md
+      - Recitation 2 - Team Contract Workshop: recitations/reci2-teamcontract.md
       # - Recitation 3 - Deployment: recitations/reci3-deployment.md
       # - Recitation 4 - Archaeology: recitations/reci4-archaeology.md
       # - Recitation 6 - Midterm Review: recitations/reci6-midterm-review.md


### PR DESCRIPTION
Updated recitation handout, navigation bar, and schedule to include the team contract workshop recitation. All links work as expected in the deployment preview.