### PR TITLE
[Small Style Change] Fixed the install hyperlink for Qlty in 2_refactoring.md

### DIFF
--- a/docs/projects/P1/2_refactoring.md
+++ b/docs/projects/P1/2_refactoring.md
@@ -45,7 +45,7 @@ If you are not familiar with any of these steps, you are **highly recommended** 
 [Qlty](https://github.com/qltysh/qlty) is a multi-language static analysis tool that supports linting, scanning, and auto-formatting across a large number of languages and technologies, including Javascript.
 For this assignment, you will locally install and configure the Qlty command-line tool to identify maintainability issues within the codebase.
 
-To get started, you will need to install Qlty on your machine: https://github.com/qltysh/qlty?tab=readme-ov-file#-quick-start.
+To get started, you will need to [install Qlty](https://github.com/qltysh/qlty?tab=readme-ov-file#-quick-start) on your machine.
 If you are using the DevContainer, everything should already be installed for you.
 
 To use Qlty to show all of the code smells within the project, you should run:


### PR DESCRIPTION
The install link for Qlty (https://github.com/qltysh/qlty?tab=readme-ov-file#-quick-start) was previously not showing up as text, not hyperlink.