### PR TITLE
style: clarify due date for presentation P2B

### DIFF
--- a/docs/projects/P2/2_firstsprint.md
+++ b/docs/projects/P2/2_firstsprint.md
@@ -2,10 +2,10 @@
 
 ## Deliverables
 
-**First Sprint** – 95 points – due Friday, September 26th, 11:59pm
+**First Sprint** – 95 points - **Presentation held in Recitation on Monday, September 22nd**
 
-- [Process & Implementation Interim](#process-and-implementation-interim-50-pts) (50 pts)
-- [Checkpoint Presentation](#checkpoint-presentation-45-pts) (45 pts) - **Held in Recitation on Monday, September 22nd**
+- [Process & Implementation Interim](#process-and-implementation-interim-50-pts) (50 pts) - due Friday, September 26th, 11:59pm
+- [Checkpoint Presentation](#checkpoint-presentation-45-pts) (45 pts) - due Sunday, September 21st, 11:59pm 
 
 
 ## Process and Implementation Interim (50 pts)


### PR DESCRIPTION
Previously, in the file `docs/projects/P2/2_firstsprint.md`, it said that P2B was due Friday, even though the presentation is due the Monday leading up to that Friday. To prevent late submissions for the presentations, clarifying the differeing due dates for the two tasks would be beneficial.

**Before:**
<img width="1278" height="364" alt="Screenshot 2025-09-17 at 2 23 44 PM" src="https://github.com/user-attachments/assets/171dd947-4eac-48df-915e-7785379841e6" />

**Updated:**
<img width="1280" height="356" alt="Screenshot 2025-09-17 at 2 23 17 PM" src="https://github.com/user-attachments/assets/9053d47d-5b18-479f-8c5e-3ab7136ab7a7" />
