### PR TITLE
Incorporating new Resources Tab with existing resources all in one location

### DIFF
--- a/docs/extra_resources.md
+++ b/docs/extra_resources.md
@@ -1,0 +1,5 @@
+# Extra Resources
+
+This page will contain links to useful Google Docs and other resources.
+
+Running/up to date [guide](https://docs.google.com/document/d/1X490SwaJbtus0KPBsjKlnNZOxUs30upkSyIvWykXkrA/edit?tab=t.0#heading=h.yfcvmuhkukvu) on Commits

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,12 @@ nav:
       # - Recitation 11 - Open Source Project and Task Selection Check In: recitations/reci11-p5-checkin.md
       # - Recitation 11 - Midterm Review: recitations/reci11-midterm-review.md
   - Hall of Fame: hall-of-fame.md
+  - Resources:
+      - Development Tools Guide: projects/P1/development-tools-guide.md
+      - Git Commands Reference: projects/P1/git-commands-reference.md
+      - Documentation: projects/P1/documentation.md
+      - GitHub Guide: projects/P1/github.md
+      - Extra Resources: extra_resources.md
   - Canvas: https://canvas.cmu.edu/courses/48397 #need to update Canvas Link
   - Gradescope: https://www.gradescope.com/courses/1086939 #need to update Gradescope link
   - Slack: https://join.slack.com/t/cmu-313-f25/shared_invite/zt-3b8qpmag7-a55JyrJ8XmWl69TZDAlcpw


### PR DESCRIPTION
New Resources Tab at the top, linking to existing pages from P1 to help guide students when they need help with "basic" software engineering issues